### PR TITLE
Fix for Malformed \uxxxx encoding error during make configure

### DIFF
--- a/openj9.build/include/top.xml
+++ b/openj9.build/include/top.xml
@@ -345,7 +345,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 				<arg value="-XshowSettings:properties"/>
 				<arg value="-version"/>
 			</exec>
-			<loadproperties srcFile="${properties_file}" prefix="@{java.id}." prefixValues="false"/>
+			<loadproperties srcFile="${properties_file}" prefix="@{java.id}." prefixValues="false">
+				<filterchain>
+					<replacestring from="\" to="\\" />
+				</filterchain>
+			</loadproperties>
 			<echoproperties>
 				<propertyset>
 					<propertyref prefix="@{java.id}."/>


### PR DESCRIPTION
Running build configure throws a malformed encoding exception
if there is "\u" character appearing in the PATH on Windows.
This fix resolves the issue by changing the single "\" to "\\"
in the generated file.

Fixes: #4

Signed-off-by: sabkrish <sabkrish@in.ibm.com>