### PR TITLE
Fix for broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the test cases which can be run against the OpenJ9 java implmentation but not OpenJDK.
 
-The tests all run under the [STF System Test Framework](https:github.com/adoptopenjdk/stf).
+The tests all run under the [STF System Test Framework](https://github.com/AdoptOpenJDK/stf).
 
 [Quick start (Unix)](#unix)  
 [Quick start (Windows)](#windows)  


### PR DESCRIPTION
Corrected the broken URL for "STF Sytem Test Framework" in README.md file.

Fixes #9

Signed-off-by: Bhargavi Mullapudi mubharga@in.ibm.com