### PR TITLE
Changes made to build.xml

### DIFF
--- a/openj9.test.sharedClasses.jvmti/build.xml
+++ b/openj9.test.sharedClasses.jvmti/build.xml
@@ -74,7 +74,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 	<target name="setup-native-build-command">
 		<echo message="building natives for java-platform ${java8_platform}"/>
-		<property name="native_build_command" value='${setup_windows_build_env}make -C ${native_src_dir} SRCDIR=${native_src_dir} PLATFORM=${java8_platform} JAVA_HOME=${java8_home} OUTDIR=${native_bin_dir}'/>
+		<property name="native_build_command" value='${setup_windows_build_env}make -C ${native_src_dir} SRCDIR="${native_src_dir}" PLATFORM=${java8_platform} JAVA_HOME="${java8_home}" OUTDIR="${native_bin_dir}"'/>
 		<tempfile property="native_build_command_file" destDir="${java.io.tmpdir}" prefix="openj9.build.command."/>
 	</target>
 


### PR DESCRIPTION
Added double quotes where the variables JAVA_HOME, SRCDIR and OUTDIR are
being set in the build.xml under openj9.test.sharedClasses.jvmti so as to
recognise paths as contiguous even with spaces in directory names.

Fixes : #11

Signed-off-by: Tanvi Kini <tanvkini@in.ibm.com>