### PR TITLE
Temporarily exclude native sharedClasses tests from running on Windows

### DIFF
--- a/openj9.test.sharedClasses.jvmti/build.xml
+++ b/openj9.test.sharedClasses.jvmti/build.xml
@@ -71,7 +71,12 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<target name="build-no-natives" depends="check-prereqs, build-dependencies, check-prereqs, build-archives">
 	</target>
 
+	<!--Temporarily excluding the native tests from building on Windows 
+			 due to : https://github.com/eclipse/openj9-systemtest/issues/38 
 	<target name="build-natives" depends="check-prereqs, setup-native-build-command, build-natives-windows, build-natives-unix">
+	</target>-->
+	
+	<target name="build-natives" depends="check-prereqs, setup-native-build-command, build-natives-unix">
 	</target>
 
 	<target name="setup-native-build-command">

--- a/openj9.test.sharedClasses.jvmti/src/test.sharedClasses.jvmti/net/openj9/stf/SharedClassesAPI.java
+++ b/openj9.test.sharedClasses.jvmti/src/test.sharedClasses.jvmti/net/openj9/stf/SharedClassesAPI.java
@@ -186,25 +186,29 @@ public class SharedClassesAPI implements SharedClassesPluginInterface {
 							.addProjectToClasspath("openj9.test.sharedClasses.jvmti")
 							.runClass(SharedClassesCacheChecker.class));
 			} else {
-				// Verify caches using a JVMTI native agent
-				String nativeExt    =  PlatformFinder.isWindows() ? ".dll" : ".so";
-				String nativePrefix =  PlatformFinder.isWindows() ? "" : "lib";
-				FileRef agent = test.env().findTestDirectory("openj9.test.sharedClasses.jvmti/bin/native")
-						.childDirectory(test.env().getPlatform())
-						.childFile(nativePrefix + "sharedClasses" + nativeExt);
-				
-				if (!cacheDir.isEmpty()) {
-					cacheDir = "," + cacheDir;
+				// Temporarily excluding the native tests from running on Windows 
+				//    due to: https://github.com/eclipse/openj9-systemtest/issues/38 
+				if ( !PlatformFinder.isWindows() ) {
+					// Verify caches using a JVMTI native agent
+					String nativeExt    =  PlatformFinder.isWindows() ? ".dll" : ".so";
+					String nativePrefix =  PlatformFinder.isWindows() ? "" : "lib";
+					FileRef agent = test.env().findTestDirectory("openj9.test.sharedClasses.jvmti/bin/native")
+							.childDirectory(test.env().getPlatform())
+							.childFile(nativePrefix + "sharedClasses" + nativeExt);
+					
+					if (!cacheDir.isEmpty()) {
+						cacheDir = "," + cacheDir;
+					}
+					String agentOptions = "expectedCacheCount=" + apiTest.expectedCacheCount + ","
+							+ "deleteCaches=true,"
+							+ "cachePrefix=" + apiTest.name() + cacheDir;
+					
+					sharedClasses.doVerifyCachesUsingJVMTI(commentPrefix + "Verify caches using JVMTI",
+							apiTest.name(), 
+							utilities,
+							iteratorCache,
+							"-agentpath:" + agent + "=" + agentOptions);
 				}
-				String agentOptions = "expectedCacheCount=" + apiTest.expectedCacheCount + ","
-						+ "deleteCaches=true,"
-						+ "cachePrefix=" + apiTest.name() + cacheDir;
-				
-				sharedClasses.doVerifyCachesUsingJVMTI(commentPrefix + "Verify caches using JVMTI",
-						apiTest.name(), 
-						utilities,
-						iteratorCache,
-						"-agentpath:" + agent + "=" + agentOptions);
 			}
 		}
 	}


### PR DESCRIPTION
Temporarily exclude native sharedClasses tests from running on Windows
Signed-off-by: Mesbah <Mesbah_Alam@ca.ibm.com>