### PR TITLE
Updated SCC test to be invoked twice

### DIFF
--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClasses.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClasses.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2017, 2018 IBM Corp.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -244,6 +244,15 @@ public class SharedClasses implements SharedClassesPluginInterface {
 
 		// Launch 5 Java processes concurrently to populate the Shared Classes cache.
 		String comment = "Start java processes using " + scTest.testClass.getSimpleName();
+		test.doRunForegroundProcesses(comment, scTest.mnemonic, 5, ECHO_ON, ExpectedOutcome.cleanRun().within("1h"), 
+				test.createJavaProcessDefinition()
+					.addJvmOption(defaultScOptions)
+					.addProjectToClasspath("openj9.test.sharedClasses")
+					.runClass(scTest.testClass)
+					.addArg(localSharedClassesResources)
+					.addArg(scTest.classArgs));
+
+		// Launch 5 Java processes concurrently to load from the Shared Classes cache.
 		test.doRunForegroundProcesses(comment, scTest.mnemonic, 5, ECHO_ON, ExpectedOutcome.cleanRun().within("1h"), 
 				test.createJavaProcessDefinition()
 					.addJvmOption(defaultScOptions)


### PR DESCRIPTION
The problem with the sharedClasses test right now is
that even though there are 5 JVMs invoked, which means
that some JVMs will load AOT code compiled by a different
JVM, it doesn't fully test the AOT load infrastructure
becuase after the test is completed, the SCC gets
destroyed before the next test runs. This commit addresses
this issue by invoking the test twice; once to primarily
populate the SCC, and a second time to primarily load
from it.

https://github.com/eclipse/openj9/issues/3774

Signed-off-by: Irwin D'Souza <dsouzai@ca.ibm.com>