### PR TITLE
Fix space after LFLAGS in sharedClasses.jvmti build makefile

### DIFF
--- a/openj9.test.sharedClasses.jvmti/src/native/Makefile
+++ b/openj9.test.sharedClasses.jvmti/src/native/Makefile
@@ -207,7 +207,7 @@ build: $(_OUTDIR) $(DESTDIR) $(DESTDIR)/$(PREFIX)sharedClasses$(SUFFIX)
 ######################
 
 $(DESTDIR)/$(PREFIX)sharedClasses$(SUFFIX) : $(OBJDIR)/sharedClasses$(OSUFFIX)
-	$(LD) $(LFLAGS)$ @ $<
+	$(LD) $(LFLAGS) $@ $<
 ifneq ($(WIN),1)
 	$(CHMOD) 755 $@
 endif


### PR DESCRIPTION
https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/212
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>