### PR TITLE
Disable core dump generation for openj9 load tests

### DIFF
--- a/openj9.test.load/src/test.load/net/openj9/stf/DaaLoadTest.java
+++ b/openj9.test.load/src/test.load/net/openj9/stf/DaaLoadTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2018 IBM Corp.
+* Copyright (c) 2016, 2019 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -101,7 +101,7 @@ public class DaaLoadTest implements StfPluginInterface {
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.JUNIT)
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.HAMCREST)
 				.addProjectToClasspath("openj9.test.daa")
-				.generateCoreDumpAtFirstLoadTestFailure(true)
+				.generateCoreDumpAtFirstLoadTestFailure(false)
 				.addSuite("daa")
 				.setSuiteThreadCount(cpuCount - 2, 2)  
 				.setSuiteNumTests(numDaaTests * workload.multiplier)

--- a/openj9.test.load/src/test.load/net/openj9/stf/HeapHogLoadTest.java
+++ b/openj9.test.load/src/test.load/net/openj9/stf/HeapHogLoadTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2018 IBM Corp.
+* Copyright (c) 2016, 2019 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -71,7 +71,7 @@ public class HeapHogLoadTest implements StfPluginInterface {
 				.addProjectToClasspath("openjdk.test.lang")    // For mini-mix inventory
 				.addProjectToClasspath("openjdk.test.util")    // For mini-mix inventory
 				.addProjectToClasspath("openjdk.test.math")    // For mini-mix inventory
-				.generateCoreDumpAtFirstLoadTestFailure(true)
+				.generateCoreDumpAtFirstLoadTestFailure(false)
 				.addSuite("HeapHog")
 				.setSuiteThreadCount(cpuCount - 2, 2)   // Leave 1 CPU for the JIT, one for GC, but never less then two threads on machines with one or two CPUs 
 				.setSuiteNumTests(numTests * 150)   // About 5 minutes run time with no -X options

--- a/openj9.test.load/src/test.load/net/openj9/stf/ObjectTreeLoadTest.java
+++ b/openj9.test.load/src/test.load/net/openj9/stf/ObjectTreeLoadTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2018 IBM Corp.
+* Copyright (c) 2016, 2019 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -69,7 +69,7 @@ public class ObjectTreeLoadTest implements StfPluginInterface {
 				.addProjectToClasspath("openjdk.test.lang")    // For mini-mix inventory
 				.addProjectToClasspath("openjdk.test.util")    // For mini-mix inventory
 				.addProjectToClasspath("openjdk.test.math")    // For mini-mix inventory
-				.generateCoreDumpAtFirstLoadTestFailure(true)
+				.generateCoreDumpAtFirstLoadTestFailure(false)
 				.addSuite("ObjectTree")
 				.setSuiteThreadCount(cpuCount - 2, 2)   // Leave 1 CPU for the JIT, one for GC, but never less then two threads on machines with one or two CPUs 
 				.setSuiteNumTests(numTests * 150)   // About 5 minutes run time with no -X options


### PR DESCRIPTION
Disable core dump generation for openj9 load tests
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>