### PR TITLE
Only destroy test specific caches at setup and teardown of SCC tests

### DIFF
--- a/openj9.stf.extensions/src/stf.extensions/net/openj9/stf/sharedClasses/StfSharedClassesExtension.java
+++ b/openj9.stf.extensions/src/stf.extensions/net/openj9/stf/sharedClasses/StfSharedClassesExtension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2018 IBM Corp.
+* Copyright (c) 2016, 2019 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -126,7 +126,7 @@ public class StfSharedClassesExtension implements StfExtension {
 	 * @throws StfException if anything goes wrong.
 	 */
 	public void doDestroySpecificCache(String comment, String scOptions, String cacheName, String cacheDir) throws StfException {
-		String cacheOperation =  ",destroyAll";
+		String cacheOperation =  ",destroy";
 		
 		generator.startNewCommand(comment, "java", "Destroy specific shared classes cache",
 						"Options:", scOptions,
@@ -134,7 +134,7 @@ public class StfSharedClassesExtension implements StfExtension {
 						"CacheDir:", cacheDir,
 						"CacheOperation:", cacheOperation); 
 
-		String[] expectedMessages = {"shared cache \"" + cacheName + "\" has been destroyed", "cache \"" + cacheName + "\" is destroyed"};
+		String[] expectedMessages = {"shared cache \"" + cacheName + "\" has been destroyed", "cache \"" + cacheName + "\" is destroyed", "No shared class caches available", "Cache does not exist"};
 		
 		runSharedClassesCacheCommand(comment, StfDuration.ofMinutes(1), expectedMessages, resolveSharedClassesOptions(scOptions, cacheName, cacheDir, cacheOperation));
 	}
@@ -153,7 +153,7 @@ public class StfSharedClassesExtension implements StfExtension {
 	 * @throws StfException if anything goes wrong.
 	 */
 	public void doDestroySpecificNonPersistentCache(String comment, String scOptions, String cacheName, String cacheDir) throws StfException {
-		String cacheOperation =  ",destroyAll,nonpersistent";
+		String cacheOperation =  ",destroy,nonpersistent";
 		
 		generator.startNewCommand(comment, "java", "Destroy specific non-persistent shared classes cache",
 				"Options:", scOptions,
@@ -161,7 +161,7 @@ public class StfSharedClassesExtension implements StfExtension {
 				"CacheDir:", cacheDir,
 				"CacheOperation:", cacheOperation); 
 		
-		String[] expectedMessages = {"shared cache \"" + cacheName + "\" has been destroyed", "cache \"" + cacheName + "\" is destroyed"};		
+		String[] expectedMessages = {"shared cache \"" + cacheName + "\" has been destroyed", "cache \"" + cacheName + "\" is destroyed", "No shared class caches available", "Cache does not exist"};		
 		
 		runSharedClassesCacheCommand(comment, StfDuration.ofMinutes(1), expectedMessages, resolveSharedClassesOptions(scOptions, cacheName, cacheDir, cacheOperation));
 	}

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClassesWorkloadTest_Softmx_Increase.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClassesWorkloadTest_Softmx_Increase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corp.
+* Copyright (c) 2016, 2019 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -59,7 +59,6 @@ public class SharedClassesWorkloadTest_Softmx_Increase implements SharedClassesP
 	private final int CACHESIZE_HARD_LIMIT = 20;
 	private final int CACHESIZE_SOFTLIMIT_1MB = 1; 
 	private final int CACHESIZE_SOFTLIMIT_2MB = 2; 
-	private final String CACHE_NAME = "workload_cache";
 	private final String[] CACHE_FULL_MESSAGE = {"Cache is 100% soft full"}; 
 	
 	private DirectoryRef cacheDirLocation;
@@ -89,7 +88,7 @@ public class SharedClassesWorkloadTest_Softmx_Increase implements SharedClassesP
 		cacheDir = cacheDirLocation.toString();
 		
 		// Specify the cache specific variables.
-		cacheSpecificGeneralOptions = "-Xshareclasses:" + "name=" + CACHE_NAME + "," + "cacheDir=" + cacheDirLocation;
+		cacheSpecificGeneralOptions = "-Xshareclasses:" + "name=" + SCSoftmxTestUtil.CACHE_NAME + "," + "cacheDir=" + cacheDir;
 
 		// Create the directories for the cache.
 		test.doMkdir("Create the cache directory", cacheDirLocation);
@@ -102,10 +101,10 @@ public class SharedClassesWorkloadTest_Softmx_Increase implements SharedClassesP
 		cacheSizeAdjustmentOptions = cacheSpecificGeneralOptions + "," + 
                    "adjustsoftmx=" + CACHESIZE_SOFTLIMIT_2MB + "m";
 
-		// To ensure we run from a clean state, attempt to destroy all persistent/non-persistent caches 
+		// To ensure we run from a clean state, attempt to destroy the test related persistent/non-persistent caches 
 		// from the default cache location which may have been left behind by a previous failed test.
-		sharedClasses.doDestroyAllPersistentCaches("Destroy Persistent Shared Classes Caches");
-		sharedClasses.doDestroyAllNonPersistentCaches("Destroy Non-Persistent Shared Classes Caches");
+		sharedClasses.doDestroySpecificCache("Destroy cache", cacheSpecificGeneralOptions + "${cacheOperation}", SCSoftmxTestUtil.CACHE_NAME, cacheDir);
+		sharedClasses.doDestroySpecificNonPersistentCache("Destroy cache", cacheSpecificGeneralOptions + "${cacheOperation}", SCSoftmxTestUtil.CACHE_NAME, cacheDir);
 	}
 	
 	public void execute(StfCoreExtension test, StfSharedClassesExtension sharedClasses) throws Exception {
@@ -127,7 +126,7 @@ public class SharedClassesWorkloadTest_Softmx_Increase implements SharedClassesP
 				"Jvm1", ECHO_OFF, ExpectedOutcome.exitValue(0,1).within("15m"), loadTestSpecificationVM1);
 		
 		// Check that the expected cache was created, caches exist, and the cache is 100% soft fullt.
-		verifyAndPrintCache(sharedClasses, CACHE_NAME, cacheDir, CACHE_NAME, 1, CACHE_FULL_MESSAGE);
+		verifyAndPrintCache(sharedClasses, SCSoftmxTestUtil.CACHE_NAME, cacheDir, SCSoftmxTestUtil.CACHE_NAME, 1, CACHE_FULL_MESSAGE);
 		
 		// Increase cache size via softmx and load more classes to fill it up again. 
 		StfProcess p = test.doRunForegroundProcess("Increasing cache size to " + CACHESIZE_SOFTLIMIT_2MB + 
@@ -146,13 +145,13 @@ public class SharedClassesWorkloadTest_Softmx_Increase implements SharedClassesP
 
 		// Confirm that only the expected cache exists and no other caches were created 
 		// Also, confirm that increasing the cache size via softmx allowed new code to be written. 
-		verifyAndPrintCache(sharedClasses, CACHE_NAME, cacheDir, CACHE_NAME, 1, CACHE_FULL_MESSAGE);
+		verifyAndPrintCache(sharedClasses, SCSoftmxTestUtil.CACHE_NAME, cacheDir, SCSoftmxTestUtil.CACHE_NAME, 1, CACHE_FULL_MESSAGE);
 		
 		// Destroy the existing cache.
-		sharedClasses.doDestroySpecificCache("Destroy cache", cacheSpecificGeneralOptions + "${cacheOperation}", CACHE_NAME, cacheDir);
+		sharedClasses.doDestroySpecificCache("Destroy cache", cacheSpecificGeneralOptions + "${cacheOperation}", SCSoftmxTestUtil.CACHE_NAME, cacheDir);
 		
 		// Confirm that the deletion was successful.
-		sharedClasses.doVerifySharedClassesCache("Verify caches", cacheSpecificGeneralOptions + "${cacheOperation}", CACHE_NAME, cacheDir, "", 0);
+		sharedClasses.doVerifySharedClassesCache("Verify caches", cacheSpecificGeneralOptions + "${cacheOperation}", SCSoftmxTestUtil.CACHE_NAME, cacheDir, "", 0);
 	}
 	
 	private void verifyAndPrintCache(StfSharedClassesExtension sharedClasses, String cacheName, String cacheDir, String expectedCacheName, int expectedCaches, String[] expectedMessages) throws Exception {
@@ -164,10 +163,10 @@ public class SharedClassesWorkloadTest_Softmx_Increase implements SharedClassesP
 	}
 	
 	public void tearDown(StfCoreExtension test, StfSharedClassesExtension sharedClasses) throws Exception {
-		// Destroy all persistent/non-persistent caches from the default cache location which may
+		// Destroy all test related persistent/non-persistent caches from the default cache location which may
 		// have been left behind by a failure. We don't care about caches left behind in results
 		// as those will get deleted together with results.
-		sharedClasses.doDestroyAllPersistentCaches("Destroy Persistent Shared Classes Caches");
-		sharedClasses.doDestroyAllNonPersistentCaches("Destroy Non-Persistent Shared Classes Caches");
+		sharedClasses.doDestroySpecificCache("Destroy cache", cacheSpecificGeneralOptions + "${cacheOperation}", SCSoftmxTestUtil.CACHE_NAME, cacheDir);
+		sharedClasses.doDestroySpecificNonPersistentCache("Destroy cache", cacheSpecificGeneralOptions + "${cacheOperation}", SCSoftmxTestUtil.CACHE_NAME, cacheDir);
 	}
 }

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClassesWorkloadTest_Softmx_IncreaseDecrease.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClassesWorkloadTest_Softmx_IncreaseDecrease.java
@@ -59,7 +59,6 @@ public class SharedClassesWorkloadTest_Softmx_IncreaseDecrease implements Shared
 	private final int CACHESIZE_HARD_LIMIT_MB = 40;
 	private final int CACHESIZE_SOFTLIMIT_INITIAL_MB = 10; 
 	private final int CACHESIZE_SOFTLIMIT_INTERMIEDIATE_INCREASED_MB = 25;
-	private final String CACHE_NAME = "workload_cache";
 	
 	private DirectoryRef cacheDirLocation;
 	private String cacheSpecificGeneralOptions;
@@ -92,7 +91,7 @@ public class SharedClassesWorkloadTest_Softmx_IncreaseDecrease implements Shared
 		cacheDir = cacheDirLocation.toString();
 		
 		// Specify the cache specific variables.
-		cacheSpecificGeneralOptions = "-Xshareclasses:" + "name=" + CACHE_NAME + "," + 
+		cacheSpecificGeneralOptions = "-Xshareclasses:" + "name=" + SCSoftmxTestUtil.CACHE_NAME + "," + 
 									  "cacheDir=" + cacheDirLocation + "," + "verboseIO";
 		
 		initialCacheSizeOptions = cacheSpecificGeneralOptions + " -XX:SharedCacheHardLimit=" + CACHESIZE_HARD_LIMIT_MB + "m " + 
@@ -107,10 +106,10 @@ public class SharedClassesWorkloadTest_Softmx_IncreaseDecrease implements Shared
 		// Create the directories for the cache.
 		test.doMkdir("Create the cache directory", cacheDirLocation);
 
-		// To ensure we run from a clean state, attempt to destroy all persistent/non-persistent caches 
+		// To ensure we run from a clean state, attempt to destroy test specific persistent/non-persistent caches 
 		// from the default cache location which may have been left behind by a previous failed test.
-		sharedClasses.doDestroyAllPersistentCaches("Destroy Persistent Shared Classes Caches");
-		sharedClasses.doDestroyAllNonPersistentCaches("Destroy Non-Persistent Shared Classes Caches");
+		sharedClasses.doDestroySpecificCache("Destroy cache", cacheSpecificGeneralOptions + "${cacheOperation}", SCSoftmxTestUtil.CACHE_NAME, cacheDir);
+		sharedClasses.doDestroySpecificNonPersistentCache("Destroy cache", cacheSpecificGeneralOptions + "${cacheOperation}", SCSoftmxTestUtil.CACHE_NAME, cacheDir);
 	}
 	
 	public void execute(StfCoreExtension test, StfSharedClassesExtension sharedClasses) throws Exception {
@@ -177,7 +176,7 @@ public class SharedClassesWorkloadTest_Softmx_IncreaseDecrease implements Shared
 		
 		// Make sure that the cache is 100% soft full. 
 		String[] expectedMessages2 = {"Cache is 100% soft full"};
-		verifyAndPrintCache(sharedClasses, CACHE_NAME, cacheDir, CACHE_NAME, 1, expectedMessages2);
+		verifyAndPrintCache(sharedClasses, SCSoftmxTestUtil.CACHE_NAME, cacheDir, SCSoftmxTestUtil.CACHE_NAME, 1, expectedMessages2);
 				
 		// Run the third workload (jvm3) in background mode that drives a new workload. 
 		// This should trigger a cache write failure.
@@ -198,10 +197,10 @@ public class SharedClassesWorkloadTest_Softmx_IncreaseDecrease implements Shared
 				"Failed to store class");
 		
 		// Destroy the existing cache.
-		sharedClasses.doDestroySpecificCache("Destroy cache", cacheSpecificGeneralOptions + "${cacheOperation}", CACHE_NAME, cacheDir);
+		sharedClasses.doDestroySpecificCache("Destroy cache", cacheSpecificGeneralOptions + "${cacheOperation}", SCSoftmxTestUtil.CACHE_NAME, cacheDir);
 		
 		// Confirm that the deletion was successful.
-		sharedClasses.doVerifySharedClassesCache("Verify caches", cacheSpecificGeneralOptions + "${cacheOperation}", CACHE_NAME, cacheDir, "", 0);
+		sharedClasses.doVerifySharedClassesCache("Verify caches", cacheSpecificGeneralOptions + "${cacheOperation}", SCSoftmxTestUtil.CACHE_NAME, cacheDir, "", 0);
 	}
 
 	private void verifyAndPrintCache(StfSharedClassesExtension sharedClasses, String cacheName, String cacheDir, String expectedCacheName, int expectedCaches, String[] expectedMessages) throws Exception {
@@ -213,10 +212,10 @@ public class SharedClassesWorkloadTest_Softmx_IncreaseDecrease implements Shared
 	}
 	
 	public void tearDown(StfCoreExtension test, StfSharedClassesExtension sharedClasses) throws Exception {
-		// Destroy all persistent/non-persistent caches from the default cache location which may
+		// Destroy the test specific persistent/non-persistent caches from the default cache location which may
 		// have been left behind by a failure. We don't care about caches left behind in results
 		// as those will get deleted together with results.
-		sharedClasses.doDestroyAllPersistentCaches("Destroy Persistent Shared Classes Caches");
-		sharedClasses.doDestroyAllNonPersistentCaches("Destroy Non-Persistent Shared Classes Caches");
+		sharedClasses.doDestroySpecificCache("Destroy cache", cacheSpecificGeneralOptions + "${cacheOperation}", SCSoftmxTestUtil.CACHE_NAME, cacheDir);
+		sharedClasses.doDestroySpecificNonPersistentCache("Destroy cache", cacheSpecificGeneralOptions + "${cacheOperation}", SCSoftmxTestUtil.CACHE_NAME, cacheDir);
 	}
 }

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/SCSoftmxTestUtil.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/SCSoftmxTestUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2018 IBM Corp.
+* Copyright (c) 2016, 2019 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -37,6 +37,7 @@ public class SCSoftmxTestUtil {
 	public static final String SLEEP = "sleep";
     public static final String MERGE_FILE = "MergeFile";
     public static final String COMPARE_AOT_JIT_DATA_SPACE = "CompareAOTJITData";
+    public static final String CACHE_NAME = "SCC_SysTest_Workload_Cache";
 	
 	public static void main (String [] args) throws Exception {
 		String task = System.getProperty("task");


### PR DESCRIPTION
Only destroy test specific caches at setup and teardown of tests
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>