### PR TITLE
Use reduced load for -Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation

### DIFF
--- a/openj9.test.load/src/test.load/net/openj9/stf/DaaLoadTest.java
+++ b/openj9.test.load/src/test.load/net/openj9/stf/DaaLoadTest.java
@@ -105,7 +105,11 @@ public class DaaLoadTest implements StfPluginInterface {
 	public void pluginInit(StfCoreExtension test) throws StfException {
 		// Find out which workload we need to run
 		StfTestArguments testArgs = test.env().getTestProperties("workload=[daaAll]");
-		specialTest = test.isJavaArgPresent(Stage.EXECUTE, "-Xjit:count=0"); 
+		
+		if ( test.isJavaArgPresent(Stage.EXECUTE, "-Xjit:count=0")
+			|| test.isJavaArgPresent(Stage.EXECUTE, "-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation")) {
+			specialTest = true;
+		}
 		
 		if(specialTest) {
 			workloadSpecial = testArgs.decodeEnum("workload", WorkloadsSpecial.class);


### PR DESCRIPTION
- Related to : https://github.com/eclipse/openj9-systemtest/issues/95
- Use reduced workload when following special mode is used: `-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation`

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>