### PR TITLE
Treat -Xjit:count=0,optlevel=warm,gcOnResolve,rtResolve as slow arg

### DIFF
--- a/openj9.test.load/src/test.load/net/openj9/stf/DaaLoadTest.java
+++ b/openj9.test.load/src/test.load/net/openj9/stf/DaaLoadTest.java
@@ -107,6 +107,7 @@ public class DaaLoadTest implements StfPluginInterface {
 		StfTestArguments testArgs = test.env().getTestProperties("workload=[daaAll]");
 		
 		if ( test.isJavaArgPresent(Stage.EXECUTE, "-Xjit:count=0")
+			|| test.isJavaArgPresent(Stage.EXECUTE, "-Xjit:count=0,optlevel=warm,gcOnResolve,rtResolve")
 			|| test.isJavaArgPresent(Stage.EXECUTE, "-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation")) {
 			specialTest = true;
 		}


### PR DESCRIPTION
Related to https://github.com/eclipse/openj9-systemtest/issues/95#issuecomment-536212996

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>