### PR TITLE
WIP : Use encoding ISO-8859-1 for compiling system tests

### DIFF
--- a/openj9.stf.extensions/build.xml
+++ b/openj9.stf.extensions/build.xml
@@ -95,7 +95,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="${src-encoding}"
+			   encoding="ISO-8859-1"
 			   includeantruntime="false"
 			   failonerror="true">
 			<compilerarg value="-Xlint:deprecation,unchecked" />

--- a/openj9.test.daa/build.xml
+++ b/openj9.test.daa/build.xml
@@ -96,7 +96,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-		       encoding="${src-encoding}"
+			   encoding="ISO-8859-1"
 			   includeantruntime="false"
 			   failonerror="true">
 			<include name="**/*.java"/>

--- a/openj9.test.jlm/build.xml
+++ b/openj9.test.jlm/build.xml
@@ -99,7 +99,7 @@
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="${src-encoding}"
+			   encoding="ISO-8859-1"
 			   includeantruntime="false"
 			   failonerror="true">
 			<include name="**/*.java"/>

--- a/openj9.test.load/build.xml
+++ b/openj9.test.load/build.xml
@@ -89,7 +89,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="${src-encoding}"
+			   encoding="ISO-8859-1"
 			   includeantruntime="false"
 			   failonerror="true">
 			<include name="**/*.java"/>

--- a/openj9.test.sharedClasses.jvmti/build.xml
+++ b/openj9.test.sharedClasses.jvmti/build.xml
@@ -129,7 +129,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="${src-encoding}"
+			   encoding="ISO-8859-1"
 			   includeantruntime="false"
 			   failonerror="true">
 			<compilerarg value="-Xlint:deprecation,unchecked" />

--- a/openj9.test.sharedClasses/build.xml
+++ b/openj9.test.sharedClasses/build.xml
@@ -99,7 +99,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="${src-encoding}"
+			   encoding="ISO-8859-1"
 			   includeantruntime="false"
 			   failonerror="true">
 			<compilerarg value="-Xlint:deprecation,unchecked" />


### PR DESCRIPTION
Related to : https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/300
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>