### PR TITLE
Print ps v <pid> debug message for linux and aix in LoaderSlaveMultiThread

### DIFF
--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClasses.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClasses.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 
 import net.adoptopenjdk.stf.environment.DirectoryRef;
 import net.adoptopenjdk.stf.environment.FileRef;
+import net.adoptopenjdk.stf.environment.JavaVersion;
 import net.adoptopenjdk.stf.environment.StfTestArguments;
 import net.adoptopenjdk.stf.extensions.core.StfCoreExtension;
 import net.adoptopenjdk.stf.processes.ExpectedOutcome;
@@ -211,7 +212,7 @@ public class SharedClasses implements SharedClassesPluginInterface {
 						.addProjectToClasspath("openj9.test.sharedClasses")
 						.runClass(JavaGen.class)
 						.addArg(sharedClassesDataDir.getSpec())
-						.addArg("10000"));
+						.addArg("2000"));
 		}
 		
 		// Copy the shared classes jar/s from the systemtest_prereqs directory to /tmp.
@@ -240,11 +241,22 @@ public class SharedClasses implements SharedClassesPluginInterface {
 		// Reset/create test-specific cache.
 		sharedClasses.doResetSharedClassesCache("Reset Shared Classes Cache", scOptions, SCSoftmxTestUtil.CACHE_NAME, cacheDir);
 
+		/*String extraOptons = "";
+		JavaVersion jvm = test.env().primaryJvm();
+		if (jvm.isIBMJvm() 
+				&& jvm.getJavaVersion() > 8
+				&& test.env().getOsgiOperatingSystemName().equals("aix")
+				&& (mode == Modes.SCM01 || mode == Modes.SCM23) 
+				&& (scTest == Tests.MultiThread)) {
+			extraOptons = "-Xmx512m"; 
+		}*/
+				
 		// Launch 5 Java processes concurrently to populate the Shared Classes cache.
 		String comment = "Start java processes using " + scTest.testClass.getSimpleName();
 		test.doRunForegroundProcesses(comment, scTest.mnemonic, 5, ECHO_ON, ExpectedOutcome.cleanRun().within("2h"), 
 				test.createJavaProcessDefinition()
 					.addJvmOption(defaultScOptions)
+					//.addJvmOption(extraOptons)
 					.addProjectToClasspath("openj9.test.sharedClasses")
 					.runClass(scTest.testClass)
 					.addArg(localSharedClassesResources)
@@ -254,6 +266,7 @@ public class SharedClasses implements SharedClassesPluginInterface {
 		test.doRunForegroundProcesses(comment, scTest.mnemonic, 5, ECHO_ON, ExpectedOutcome.cleanRun().within("2h"), 
 				test.createJavaProcessDefinition()
 					.addJvmOption(defaultScOptions)
+					//.addJvmOption(extraOptons)
 					.addProjectToClasspath("openj9.test.sharedClasses")
 					.runClass(scTest.testClass)
 					.addArg(localSharedClassesResources)

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClasses.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClasses.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 
 import net.adoptopenjdk.stf.environment.DirectoryRef;
 import net.adoptopenjdk.stf.environment.FileRef;
-import net.adoptopenjdk.stf.environment.JavaVersion;
 import net.adoptopenjdk.stf.environment.StfTestArguments;
 import net.adoptopenjdk.stf.extensions.core.StfCoreExtension;
 import net.adoptopenjdk.stf.processes.ExpectedOutcome;
@@ -212,7 +211,7 @@ public class SharedClasses implements SharedClassesPluginInterface {
 						.addProjectToClasspath("openj9.test.sharedClasses")
 						.runClass(JavaGen.class)
 						.addArg(sharedClassesDataDir.getSpec())
-						.addArg("2000"));
+						.addArg("10000"));
 		}
 		
 		// Copy the shared classes jar/s from the systemtest_prereqs directory to /tmp.
@@ -241,22 +240,11 @@ public class SharedClasses implements SharedClassesPluginInterface {
 		// Reset/create test-specific cache.
 		sharedClasses.doResetSharedClassesCache("Reset Shared Classes Cache", scOptions, SCSoftmxTestUtil.CACHE_NAME, cacheDir);
 
-		/*String extraOptons = "";
-		JavaVersion jvm = test.env().primaryJvm();
-		if (jvm.isIBMJvm() 
-				&& jvm.getJavaVersion() > 8
-				&& test.env().getOsgiOperatingSystemName().equals("aix")
-				&& (mode == Modes.SCM01 || mode == Modes.SCM23) 
-				&& (scTest == Tests.MultiThread)) {
-			extraOptons = "-Xmx512m"; 
-		}*/
-				
 		// Launch 5 Java processes concurrently to populate the Shared Classes cache.
 		String comment = "Start java processes using " + scTest.testClass.getSimpleName();
 		test.doRunForegroundProcesses(comment, scTest.mnemonic, 5, ECHO_ON, ExpectedOutcome.cleanRun().within("2h"), 
 				test.createJavaProcessDefinition()
 					.addJvmOption(defaultScOptions)
-					//.addJvmOption(extraOptons)
 					.addProjectToClasspath("openj9.test.sharedClasses")
 					.runClass(scTest.testClass)
 					.addArg(localSharedClassesResources)
@@ -266,7 +254,6 @@ public class SharedClasses implements SharedClassesPluginInterface {
 		test.doRunForegroundProcesses(comment, scTest.mnemonic, 5, ECHO_ON, ExpectedOutcome.cleanRun().within("2h"), 
 				test.createJavaProcessDefinition()
 					.addJvmOption(defaultScOptions)
-					//.addJvmOption(extraOptons)
 					.addProjectToClasspath("openj9.test.sharedClasses")
 					.runClass(scTest.testClass)
 					.addArg(localSharedClassesResources)

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/LoaderSlaveMultiThread.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/test/sc/LoaderSlaveMultiThread.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016, 2019 IBM Corp. and others
+* Copyright (c) 2016, 2020 IBM Corp. and others
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -21,20 +21,22 @@
 
 package net.openj9.test.sc;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.management.ManagementFactory;
+import java.net.URL;
 import java.net.URLClassLoader;
+import java.text.NumberFormat;
+import java.util.Calendar;
 import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 import net.openj9.test.sc.classes.Dummy;
-
-import java.io.File;
-import java.net.URL;
-import java.lang.Runnable;
-import java.util.LinkedList;
-import java.util.Iterator;
-import java.util.Calendar;
-import java.text.NumberFormat;
 
 public class LoaderSlaveMultiThread
 {
@@ -55,9 +57,38 @@ public class LoaderSlaveMultiThread
 		try
 		{
 			(new LoaderSlaveMultiThread()).run(args[0],Integer.parseInt(args[1]));
+			
+			// Print debug information: on Linux or AIX, run "ps v <pid>" on the JVM running the test
+			String os = System.getProperty("os.name").toLowerCase(); 
+			if ( os.contains("linux") || os.contains("aix")) { 
+				String pid = ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
+				runSystemCmd("ps v " + pid); 
+			}
 		}
 		catch(Exception e)
 		{
+			e.printStackTrace();
+		}
+	}
+
+	private static void runSystemCmd(String cmd) {
+		String s = null;
+
+		try {
+			Process p = Runtime.getRuntime().exec(cmd);
+			BufferedReader stdInput = new BufferedReader(new InputStreamReader(p.getInputStream()));
+			BufferedReader stdError = new BufferedReader(new InputStreamReader(p.getErrorStream()));
+			
+			System.out.println("stdout of command: " + cmd);
+			while ((s = stdInput.readLine()) != null) {
+			    System.out.println(s);
+			}
+			
+			System.out.println("stderr of command: " + cmd);
+			while ((s = stdError.readLine()) != null) {
+			    System.out.println(s);
+			}
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
 	}


### PR DESCRIPTION
- Print ps v <pid> debug message for linux and aix in LoaderSlaveMultiThread
- Related to https://github.com/eclipse/openj9/issues/8842

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>
