### PR TITLE
Use -Xdump option for all variants of SC01 test

### DIFF
--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClasses.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClasses.java
@@ -252,7 +252,7 @@ public class SharedClasses implements SharedClassesPluginInterface {
 
 		String args = scTest.classArgs;
 		
-		// If we are running any variant of SharedClasses.SCM01.x test
+		// If we are running any variant of SharedClasses.SCM01 test
 		if (mode == Modes.SCM01) {
 			args = "-Xdump:system+java:events=throw,filter=java/lang/NullPointerException#java/lang/invoke/BruteArgumentMoverHandle.permuteArguments* " + args;	
 		}

--- a/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClasses.java
+++ b/openj9.test.sharedClasses/src/test.sharedClasses/net/openj9/stf/SharedClasses.java
@@ -252,8 +252,8 @@ public class SharedClasses implements SharedClassesPluginInterface {
 
 		String args = scTest.classArgs;
 		
-		// If we are running SharedClasses.SCM01.MultiThread
-		if (mode == Modes.SCM01 && scTest.mnemonic.equals("MT")) {
+		// If we are running any variant of SharedClasses.SCM01.x test
+		if (mode == Modes.SCM01) {
 			args = "-Xdump:system+java:events=throw,filter=java/lang/NullPointerException#java/lang/invoke/BruteArgumentMoverHandle.permuteArguments* " + args;	
 		}
 		// Launch 5 Java processes concurrently to load from the Shared Classes cache.


### PR DESCRIPTION
- Use -Xdump option for all variants of SC01 test
- Related to : https://github.com/eclipse/openj9/issues/8972#issuecomment-716523940

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>