### PR TITLE
Remove hard-coded version numbers from prereq jar references

### DIFF
--- a/openj9.test.daa/.classpath
+++ b/openj9.test.daa/.classpath
@@ -1,9 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2017, 2021 IBM Corp.
+
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License 2.0 which accompanies this distribution
+and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, 
+Version 2.0 which accompanies this distribution and is available at 
+https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the 
+Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+version 2 with the GNU Classpath Exception [1] and GNU General Public License,
+version 2 with the OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
 <classpath>
 	<classpathentry kind="src" path="src/test.daa"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.core"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/junit-4.12.jar"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/hamcrest-core-1.3.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/junit.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/hamcrest-core.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/openj9.test.jlm/.classpath
+++ b/openj9.test.jlm/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2017, 2020 IBM Corp.
+Copyright (c) 2017, 2021 IBM Corp.
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License 2.0 which accompanies this distribution
@@ -24,8 +24,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.core"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/openjdk.test.jlm"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/log4j-2.13.3/log4j-api-2.13.3.jar"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/log4j-2.13.3/log4j-core-2.13.3.jar"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/log4j/log4j-api.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/log4j/log4j-core.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/junit.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/openj9.test.load/.classpath
+++ b/openj9.test.load/.classpath
@@ -1,10 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2017, 2021 IBM Corp.
+
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License 2.0 which accompanies this distribution
+and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, 
+Version 2.0 which accompanies this distribution and is available at 
+https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the 
+Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+version 2 with the GNU Classpath Exception [1] and GNU General Public License,
+version 2 with the OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
 <classpath>
 	<classpathentry kind="src" path="src/test.load"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.core"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.load"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/hamcrest-core-1.3.jar"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/hamcrest-core.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/junit.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/openj9.test.sharedClasses.jvmti/.classpath
+++ b/openj9.test.sharedClasses.jvmti/.classpath
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2017, 2021 IBM Corp.
+
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License 2.0 which accompanies this distribution
+and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, 
+Version 2.0 which accompanies this distribution and is available at 
+https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the 
+Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+version 2 with the GNU Classpath Exception [1] and GNU General Public License,
+version 2 with the OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
 <classpath>
 	<classpathentry kind="src" path="src/test.sharedClasses.jvmti"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
@@ -6,6 +26,6 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.load"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/openj9.stf.extensions"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/openj9.test.sharedClasses"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/junit.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/openj9.test.sharedClasses/.classpath
+++ b/openj9.test.sharedClasses/.classpath
@@ -1,9 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2017, 2021 IBM Corp.
+
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License 2.0 which accompanies this distribution
+and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, 
+Version 2.0 which accompanies this distribution and is available at 
+https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the 
+Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+version 2 with the GNU Classpath Exception [1] and GNU General Public License,
+version 2 with the OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
 <classpath>
 	<classpathentry kind="src" path="src/test.sharedClasses"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.core"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/openj9.stf.extensions"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/junit.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
- Removes version number from all prereq jar references in openj9-systemtest repo
- Related to : https://github.com/AdoptOpenJDK/stf/issues/98

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>